### PR TITLE
#259 [FEAT] funcionalidades e compatibilidade do componente selectinput para a nova api

### DIFF
--- a/src/components/inputs/answers/SelectInput.jsx
+++ b/src/components/inputs/answers/SelectInput.jsx
@@ -27,7 +27,7 @@ function SelectInput(props) {
 
     const handleOptionsUpdate = (optionText) => {
         if (optionText === 'defaultOption') {
-            return;
+            return setOptions({});
         }
 
         const optionFound = item.itemOptions.find((op) => op.text === optionText);

--- a/src/components/inputs/answers/SelectInput.jsx
+++ b/src/components/inputs/answers/SelectInput.jsx
@@ -1,27 +1,98 @@
-import { React } from 'react';
+import { React, useEffect, useState } from 'react';
+import TextButton from '../../TextButton';
 
 const styles = `
     .font-barlow {
         font-family: 'Barlow', sans-serif;
     }
+
+    .form-select:focus {
+        cursor: pointer;
+        box-shadow: none !important;
+    }
 `;
 
 function SelectInput(props) {
-    const options = props.item.itemOptions || [];
+    const { onAnswerChange, item, group, galleryRef } = props;
+    const [options, setOptions] = useState({});
+    const [ImageVisibility, setImageVisibility] = useState(false);
+
+    const toggleImageVisibility = () => {
+        setImageVisibility(!ImageVisibility);
+    };
+
+    useEffect(() => {
+        onAnswerChange(group, item.id, 'OPTION', options);
+    }, [options, item.id, onAnswerChange, group]);
+
+    const handleOptionsUpdate = (optionText) => {
+        if (optionText === 'defaultOption') {
+            return;
+        }
+
+        const optionFound = item.itemOptions.find((op) => op.text === optionText);
+        const optionId = optionFound.id;
+
+        setOptions(() => {
+            const newOptions = {};
+            newOptions[optionId] = '';
+            return newOptions;
+        });
+    };
+
     return (
-        <div className="rounded shadow bg-white font-barlow pt-3 px-0 mt-3">
-            <div className="row align-items-center justify-content-between m-0 pb-3">
-                <div className="d-flex col-9 align-items-center text-break text-start px-3">{props.item.text}</div>
-                <div className="col px-0">
-                    <select className="form-select border-0 rounded-3">
-                        <option disabled selected label="Selecione uma opção:"></option>
-                        {options.map((option, index) => (
-                            <option key={index} value={option.text}>
-                                {option.text}
-                            </option>
-                        ))}
-                    </select>
+        <div className="rounded shadow bg-white font-barlow pt-3 px-3">
+            <div className="row align-items-center justify-content-between pb-2 m-0">
+                <p className="text-break text-start color-dark-gray font-barlow fw-medium fs-6 lh-sm px-0 m-0">{item.text}</p>
+            </div>
+
+            {item.files.length > 0 && galleryRef && (
+                <div className="row justify-content-center m-0 ">
+                    {item.files.slice(0, ImageVisibility ? item.files.length : 3).map((image, index) => {
+                        return (
+                            <div
+                                key={'image-' + image.id}
+                                className={`col-${item.files.length > 3 ? 4 : 12 / item.files.length} m-0 px-1 px-lg-2 ${
+                                    index > 2 && 'mt-2'
+                                }`}
+                            >
+                                <div
+                                    className={`${
+                                        item.files.length > 1 && 'ratio ratio-1x1'
+                                    } border border-light-subtle rounded-4 overflow-hidden`}
+                                    onClick={() => galleryRef.current.showModal({ images: item.files, currentImage: index })}
+                                >
+                                    <img src={image.path} className="img-fluid object-fit-contain" alt="Responsive" />
+                                </div>
+                            </div>
+                        );
+                    })}
                 </div>
+            )}
+
+            {item.files.length > 3 && (
+                <div className="row justify-content-center m-0 pt-3">
+                    <TextButton
+                        className="fs-6 w-auto p-2 py-0"
+                        hsl={[190, 46, 70]}
+                        text={`Ver ${ImageVisibility ? 'menos' : 'mais'}`}
+                        onClick={toggleImageVisibility}
+                    />
+                </div>
+            )}
+
+            <div className="row px-0 py-2 m-0">
+                <select
+                    className="form-select border border-dark-subtle px-2 py-0"
+                    defaultValue="defaultOption"
+                    onChange={(e) => handleOptionsUpdate(e.target.value)}
+                >
+                    <option value="defaultOption" label="Selecione uma opção:"></option>
+                    {item.itemOptions.map((option) => {
+                        const optname = option.text.toLowerCase().replace(/\s/g, '');
+                        return <option key={optname + 'input' + item.id} value={option.text} label={option.text}></option>;
+                    })}
+                </select>
             </div>
 
             <style>{styles}</style>

--- a/src/components/inputs/answers/SelectInput.jsx
+++ b/src/components/inputs/answers/SelectInput.jsx
@@ -25,23 +25,19 @@ function SelectInput(props) {
         onAnswerChange(group, item.id, 'OPTION', options);
     }, [options, item.id, onAnswerChange, group]);
 
-    const handleOptionsUpdate = (optionText) => {
-        if (optionText === 'defaultOption') {
-            return setOptions({});
-        }
-
-        const optionFound = item.itemOptions.find((op) => op.text === optionText);
-        const optionId = optionFound.id;
-
+    const handleOptionsUpdate = (optionId) => {
         setOptions(() => {
             const newOptions = {};
-            newOptions[optionId] = '';
+            // eslint-disable-next-line
+            if (optionId != -1) {
+                newOptions[optionId] = '';
+            }
             return newOptions;
         });
     };
 
     return (
-        <div className="rounded shadow bg-white font-barlow pt-3 px-3">
+        <div className="rounded-4 shadow bg-white font-barlow p-3">
             <div className="row align-items-center justify-content-between pb-2 m-0">
                 <p className="text-break text-start color-dark-gray font-barlow fw-medium fs-6 lh-sm px-0 m-0">{item.text}</p>
             </div>
@@ -84,13 +80,13 @@ function SelectInput(props) {
             <div className="row px-0 py-2 m-0">
                 <select
                     className="form-select border border-dark-subtle px-2 py-0"
-                    defaultValue="defaultOption"
+                    defaultValue="-1"
                     onChange={(e) => handleOptionsUpdate(e.target.value)}
                 >
-                    <option value="defaultOption" label="Selecione uma opção:"></option>
+                    <option value="-1" label="Selecione uma opção:"></option>
                     {item.itemOptions.map((option) => {
                         const optname = option.text.toLowerCase().replace(/\s/g, '');
-                        return <option key={optname + 'input' + item.id} value={option.text} label={option.text}></option>;
+                        return <option key={optname + 'input' + item.id} value={option.id} label={option.text}></option>;
                     })}
                 </select>
             </div>

--- a/src/pages/ProtocolPage.jsx
+++ b/src/pages/ProtocolPage.jsx
@@ -274,7 +274,14 @@ function ProtocolPage(props) {
                                 case 'SELECT':
                                     return (
                                         <div key={item.id} className="row justify-content-center m-0 pt-3">
-                                            {<SelectInput item={item} group={itemGroup.id} onAnswerChange={handleAnswerChange} />}
+                                            {
+                                                <SelectInput
+                                                    item={item}
+                                                    galleryRef={galleryRef}
+                                                    group={itemGroup.id}
+                                                    onAnswerChange={handleAnswerChange}
+                                                />
+                                            }
                                         </div>
                                     );
                                 case 'DATEBOX':

--- a/src/pages/ProtocolPage.jsx
+++ b/src/pages/ProtocolPage.jsx
@@ -56,7 +56,7 @@ function ProtocolPage(props) {
 
     const handleAnswerChange = useCallback((groupToUpdate, itemToUpdate, itemType, updatedAnswer) => {
         setItemAnswerGroups((prevItemAnswerGroups) => {
-            const newItemAnswerGroups = prevItemAnswerGroups;
+            const newItemAnswerGroups = { ...prevItemAnswerGroups };
 
             if (newItemAnswerGroups[groupToUpdate] === undefined) {
                 newItemAnswerGroups[groupToUpdate] = { itemAnswers: {}, optionAnswers: {}, tableAnswers: {} };


### PR DESCRIPTION
- SelectInput praticamente 100% refatorado seguindo os padrões adotados em RadioButtonInput;
- Se atentar as mudanças realizadas na ProtocolPage, em especial com relação a criação de newItemAnswerGroups, se eu não fizer aquilo itemAnswerGroups simplesmente não atualiza sendo que o componente SelectInput retorna tudo conforme esperado, a princípio...
- Sugestão de como fazer o caso default da função do SelectInput são bem vindas, não pensei em nada mais prático e lógico do que aquilo;
- Eh provável que após o merge da #268 eu também adicione o suporte para Markdown ao componente SelectInput, ou seja, não devo fazer merge dessa branch mesmo que ela tenha sido aprovada antes da #268 ;